### PR TITLE
Adding geojson conversion for Nav2 Route Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,3 @@ pip install pre-commit
 pre-commit install
 pre-commit run --all-files  # Run manually
 ```
-

--- a/integration/nav2/tools/README.md
+++ b/integration/nav2/tools/README.md
@@ -1,0 +1,67 @@
+# GML to GeoJSON Converter
+
+A Python utility for converting Graph Modeling Language (GML) files to GeoJSON format for use with Nav2 Route Server.
+
+## Overview
+
+The `gml_to_geojson.py` script parses GML files containing graph data with nodes and edges, converting them to GeoJSON format suitable for navigation and routing applications.
+
+## Features
+
+- Parses GML nodes with world coordinates (x, y, z) and pixel coordinates
+- Extracts edges with source/target relationships
+- Generates bidirectional LineString features for each edge
+- Outputs valid GeoJSON with EPSG:3857 coordinate reference system
+- Supports pretty-printed JSON output
+
+## Usage
+
+```bash
+# Basic conversion
+python3 gml_to_geojson.py input.gml
+
+# Specify output file
+python3 gml_to_geojson.py input.gml -o output.geojson
+```
+
+## Arguments
+
+- `input_file`: Path to the input GML file (required)
+- `-o, --output`: Output GeoJSON file path (default: input_file.geojson)
+
+## GML Format Requirements
+
+The script expects GML files with the following structure:
+
+**Nodes:**
+```
+node [
+    id 1
+    label "node_name"
+    world 123.45 67.89 0.0
+    pixel 100 200
+]
+```
+
+**Edges:**
+```
+edge [
+    source 1
+    target 2
+    weight 1.5
+    edge_type "normal"
+]
+```
+
+## Output Format
+
+The generated GeoJSON contains:
+- Point features for each node with world coordinates
+- Bidirectional MultiLineString features for each edge
+- EPSG:3857 coordinate reference system
+- Generation timestamp
+
+## Dependencies
+
+- Python 3.x
+- Standard library modules: `re`, `json`, `argparse`, `datetime`, `typing`

--- a/integration/nav2/tools/gml_to_geojson.py
+++ b/integration/nav2/tools/gml_to_geojson.py
@@ -6,221 +6,193 @@ Converts Graph Modeling Language (GML) files to GeoJSON format for Nav2 Route Se
 The GML file is expected to contain nodes with world coordinates and edges connecting them.
 """
 
-import re
-import json
 import argparse
+import json
+import re
 from datetime import datetime
-from typing import Dict, List, Any, Tuple
+from typing import Any, Dict, List, Tuple
 
 
 def parse_gml_file(gml_file_path: str) -> Tuple[List[Dict], List[Dict]]:
     """
     Parse a GML file and extract nodes and edges.
-    
+
     Args:
         gml_file_path: Path to the GML file
-        
+
     Returns:
         Tuple of (nodes, edges) lists
     """
     nodes = []
     edges = []
-    
-    with open(gml_file_path, 'r') as file:
+
+    with open(gml_file_path) as file:
         content = file.read()
-    
+
     # Parse nodes
-    node_pattern = r'node \[(.*?)\]'
+    node_pattern = r"node \[(.*?)\]"
     node_matches = re.findall(node_pattern, content, re.DOTALL)
-    
+
     for node_match in node_matches:
         node_data = {}
-        
+
         # Extract node attributes
-        id_match = re.search(r'id (\d+)', node_match)
+        id_match = re.search(r"id (\d+)", node_match)
         if id_match:
-            node_data['id'] = int(id_match.group(1))
-        
+            node_data["id"] = int(id_match.group(1))
+
         label_match = re.search(r'label "([^"]*)"', node_match)
         if label_match:
-            node_data['label'] = label_match.group(1)
-        
+            node_data["label"] = label_match.group(1)
+
         # Extract world coordinates (x, y, z)
-        world_matches = re.findall(r'world ([\d.-]+)', node_match)
+        world_matches = re.findall(r"world ([\d.-]+)", node_match)
         if len(world_matches) >= 2:
-            node_data['x'] = float(world_matches[0])
-            node_data['y'] = float(world_matches[1])
+            node_data["x"] = float(world_matches[0])
+            node_data["y"] = float(world_matches[1])
             if len(world_matches) >= 3:
-                node_data['z'] = float(world_matches[2])
-        
+                node_data["z"] = float(world_matches[2])
+
         # Extract pixel coordinates
-        pixel_matches = re.findall(r'pixel (\d+)', node_match)
+        pixel_matches = re.findall(r"pixel (\d+)", node_match)
         if len(pixel_matches) >= 2:
-            node_data['pixel_x'] = int(pixel_matches[0])
-            node_data['pixel_y'] = int(pixel_matches[1])
-        
-        if 'id' in node_data and 'x' in node_data and 'y' in node_data:
+            node_data["pixel_x"] = int(pixel_matches[0])
+            node_data["pixel_y"] = int(pixel_matches[1])
+
+        if "id" in node_data and "x" in node_data and "y" in node_data:
             nodes.append(node_data)
-    
+
     # Parse edges
-    edge_pattern = r'edge \[(.*?)\]'
+    edge_pattern = r"edge \[(.*?)\]"
     edge_matches = re.findall(edge_pattern, content, re.DOTALL)
-    
+
     for edge_match in edge_matches:
         edge_data = {}
-        
+
         # Extract edge attributes
-        source_match = re.search(r'source (\d+)', edge_match)
+        source_match = re.search(r"source (\d+)", edge_match)
         if source_match:
-            edge_data['source'] = int(source_match.group(1))
-        
-        target_match = re.search(r'target (\d+)', edge_match)
+            edge_data["source"] = int(source_match.group(1))
+
+        target_match = re.search(r"target (\d+)", edge_match)
         if target_match:
-            edge_data['target'] = int(target_match.group(1))
-        
-        weight_match = re.search(r'weight ([\d.-]+)', edge_match)
+            edge_data["target"] = int(target_match.group(1))
+
+        weight_match = re.search(r"weight ([\d.-]+)", edge_match)
         if weight_match:
-            edge_data['weight'] = float(weight_match.group(1))
-        
+            edge_data["weight"] = float(weight_match.group(1))
+
         edge_type_match = re.search(r'edge_type "([^"]*)"', edge_match)
         if edge_type_match:
-            edge_data['edge_type'] = edge_type_match.group(1)
-        
-        if 'source' in edge_data and 'target' in edge_data:
+            edge_data["edge_type"] = edge_type_match.group(1)
+
+        if "source" in edge_data and "target" in edge_data:
             edges.append(edge_data)
-    
+
     return nodes, edges
 
 
 def create_geojson(nodes: List[Dict], edges: List[Dict]) -> Dict[str, Any]:
     """
     Convert nodes and edges to GeoJSON format.
-    
+
     Args:
         nodes: List of node dictionaries
         edges: List of edge dictionaries
-        
+
     Returns:
         GeoJSON dictionary
     """
     # Create a lookup for nodes by ID
-    node_lookup = {node['id']: node for node in nodes}
-    
+    node_lookup = {node["id"]: node for node in nodes}
+
     features = []
-    feature_id = 0
-    
+
     # Convert nodes to Point features
-    for node in nodes:
+    for feature_id, node in enumerate(nodes):
         feature = {
             "type": "Feature",
-            "properties": {
-                "id": node['id'],
-                "frame": "map"
-            },
-            "geometry": {
-                "type": "Point",
-                "coordinates": [node['x'], node['y']]
-            }
+            "properties": {"id": node["id"], "frame": "map"},
+            "geometry": {"type": "Point", "coordinates": [node["x"], node["y"]]},
         }
-        
+
         features.append(feature)
-        feature_id += 1
-    
+
     # Convert edges to LineString features
+    edge_feature_id = len(nodes)
     for edge in edges:
-        source_node = node_lookup.get(edge['source'])
-        target_node = node_lookup.get(edge['target'])
-        
+        source_node = node_lookup.get(edge["source"])
+        target_node = node_lookup.get(edge["target"])
+
         if source_node and target_node:
             # Forward direction edge
             forward_feature = {
                 "type": "Feature",
-                "properties": {
-                    "id": feature_id,
-                    "startid": edge['source'],
-                    "endid": edge['target']
-                },
+                "properties": {"id": edge_feature_id, "startid": edge["source"], "endid": edge["target"]},
                 "geometry": {
                     "type": "MultiLineString",
-                    "coordinates": [[
-                        [source_node['x'], source_node['y']],
-                        [target_node['x'], target_node['y']]
-                    ]]
-                }
+                    "coordinates": [[[source_node["x"], source_node["y"]], [target_node["x"], target_node["y"]]]],
+                },
             }
-            
+
             features.append(forward_feature)
-            feature_id += 1
-            
+            edge_feature_id += 1
+
             # Reverse direction edge
             reverse_feature = {
                 "type": "Feature",
-                "properties": {
-                    "id": feature_id,
-                    "startid": edge['target'],
-                    "endid": edge['source']
-                },
+                "properties": {"id": edge_feature_id, "startid": edge["target"], "endid": edge["source"]},
                 "geometry": {
                     "type": "MultiLineString",
-                    "coordinates": [[
-                        [target_node['x'], target_node['y']],
-                        [source_node['x'], source_node['y']]
-                    ]]
-                }
+                    "coordinates": [[[target_node["x"], target_node["y"]], [source_node["x"], source_node["y"]]]],
+                },
             }
-            
+
             features.append(reverse_feature)
-            feature_id += 1
-    
+            edge_feature_id += 1
+
     # Create the complete GeoJSON structure
-    geojson = {
+    return {
         "type": "FeatureCollection",
         "name": "graph",
-        "crs": {
-            "type": "name",
-            "properties": {
-                "name": "urn:ogc:def:crs:EPSG::3857"
-            }
-        },
+        "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:EPSG::3857"}},
         "date_generated": datetime.now().strftime("%a %b %d %I:%M:%S %p %Z %Y"),
-        "features": features
+        "features": features,
     }
-    
-    return geojson
 
 
 def main():
     """Main function to handle command line arguments and conversion."""
-    parser = argparse.ArgumentParser(description='Convert GML file to GeoJSON format')
-    parser.add_argument('input_file', help='Input GML file path')
-    parser.add_argument('-o', '--output', help='Output GeoJSON file path (default: input_file.geojson)')
-    
+    parser = argparse.ArgumentParser(description="Convert GML file to GeoJSON format")
+    parser.add_argument("input_file", help="Input GML file path")
+    parser.add_argument("-o", "--output", help="Output GeoJSON file path (default: input_file.geojson)")
+
     args = parser.parse_args()
-    
+
     # Determine output file path
     if args.output:
         output_file = args.output
     else:
-        output_file = args.input_file.rsplit('.', 1)[0] + '.geojson'
-    
+        output_file = args.input_file.rsplit(".", 1)[0] + ".geojson"
+
     try:
         print(f"Parsing GML file: {args.input_file}")
         nodes, edges = parse_gml_file(args.input_file)
         print(f"Found {len(nodes)} nodes and {len(edges)} edges")
-        
+
         print("Converting to GeoJSON...")
         geojson = create_geojson(nodes, edges)
-        
+
         print(f"Writing GeoJSON to: {output_file}")
-        with open(output_file, 'w') as f:
+        with open(output_file, "w") as f:
             json.dump(geojson, f, indent=4)
-        
+
         print("Conversion completed successfully!")
-        
+
     except Exception as e:
         print(f"Error: {e}")
         return 1
-    
+
     return 0
 
 

--- a/integration/nav2/tools/gml_to_geojson.py
+++ b/integration/nav2/tools/gml_to_geojson.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+GML to GeoJSON Converter
+
+Converts Graph Modeling Language (GML) files to GeoJSON format for Nav2 Route Server.
+The GML file is expected to contain nodes with world coordinates and edges connecting them.
+"""
+
+import re
+import json
+import argparse
+from datetime import datetime
+from typing import Dict, List, Any, Tuple
+
+
+def parse_gml_file(gml_file_path: str) -> Tuple[List[Dict], List[Dict]]:
+    """
+    Parse a GML file and extract nodes and edges.
+    
+    Args:
+        gml_file_path: Path to the GML file
+        
+    Returns:
+        Tuple of (nodes, edges) lists
+    """
+    nodes = []
+    edges = []
+    
+    with open(gml_file_path, 'r') as file:
+        content = file.read()
+    
+    # Parse nodes
+    node_pattern = r'node \[(.*?)\]'
+    node_matches = re.findall(node_pattern, content, re.DOTALL)
+    
+    for node_match in node_matches:
+        node_data = {}
+        
+        # Extract node attributes
+        id_match = re.search(r'id (\d+)', node_match)
+        if id_match:
+            node_data['id'] = int(id_match.group(1))
+        
+        label_match = re.search(r'label "([^"]*)"', node_match)
+        if label_match:
+            node_data['label'] = label_match.group(1)
+        
+        # Extract world coordinates (x, y, z)
+        world_matches = re.findall(r'world ([\d.-]+)', node_match)
+        if len(world_matches) >= 2:
+            node_data['x'] = float(world_matches[0])
+            node_data['y'] = float(world_matches[1])
+            if len(world_matches) >= 3:
+                node_data['z'] = float(world_matches[2])
+        
+        # Extract pixel coordinates
+        pixel_matches = re.findall(r'pixel (\d+)', node_match)
+        if len(pixel_matches) >= 2:
+            node_data['pixel_x'] = int(pixel_matches[0])
+            node_data['pixel_y'] = int(pixel_matches[1])
+        
+        if 'id' in node_data and 'x' in node_data and 'y' in node_data:
+            nodes.append(node_data)
+    
+    # Parse edges
+    edge_pattern = r'edge \[(.*?)\]'
+    edge_matches = re.findall(edge_pattern, content, re.DOTALL)
+    
+    for edge_match in edge_matches:
+        edge_data = {}
+        
+        # Extract edge attributes
+        source_match = re.search(r'source (\d+)', edge_match)
+        if source_match:
+            edge_data['source'] = int(source_match.group(1))
+        
+        target_match = re.search(r'target (\d+)', edge_match)
+        if target_match:
+            edge_data['target'] = int(target_match.group(1))
+        
+        weight_match = re.search(r'weight ([\d.-]+)', edge_match)
+        if weight_match:
+            edge_data['weight'] = float(weight_match.group(1))
+        
+        edge_type_match = re.search(r'edge_type "([^"]*)"', edge_match)
+        if edge_type_match:
+            edge_data['edge_type'] = edge_type_match.group(1)
+        
+        if 'source' in edge_data and 'target' in edge_data:
+            edges.append(edge_data)
+    
+    return nodes, edges
+
+
+def create_geojson(nodes: List[Dict], edges: List[Dict]) -> Dict[str, Any]:
+    """
+    Convert nodes and edges to GeoJSON format.
+    
+    Args:
+        nodes: List of node dictionaries
+        edges: List of edge dictionaries
+        
+    Returns:
+        GeoJSON dictionary
+    """
+    # Create a lookup for nodes by ID
+    node_lookup = {node['id']: node for node in nodes}
+    
+    features = []
+    feature_id = 0
+    
+    # Convert nodes to Point features
+    for node in nodes:
+        feature = {
+            "type": "Feature",
+            "properties": {
+                "id": node['id'],
+                "frame": "map"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [node['x'], node['y']]
+            }
+        }
+        
+        features.append(feature)
+        feature_id += 1
+    
+    # Convert edges to LineString features
+    for edge in edges:
+        source_node = node_lookup.get(edge['source'])
+        target_node = node_lookup.get(edge['target'])
+        
+        if source_node and target_node:
+            # Forward direction edge
+            forward_feature = {
+                "type": "Feature",
+                "properties": {
+                    "id": feature_id,
+                    "startid": edge['source'],
+                    "endid": edge['target']
+                },
+                "geometry": {
+                    "type": "MultiLineString",
+                    "coordinates": [[
+                        [source_node['x'], source_node['y']],
+                        [target_node['x'], target_node['y']]
+                    ]]
+                }
+            }
+            
+            features.append(forward_feature)
+            feature_id += 1
+            
+            # Reverse direction edge
+            reverse_feature = {
+                "type": "Feature",
+                "properties": {
+                    "id": feature_id,
+                    "startid": edge['target'],
+                    "endid": edge['source']
+                },
+                "geometry": {
+                    "type": "MultiLineString",
+                    "coordinates": [[
+                        [target_node['x'], target_node['y']],
+                        [source_node['x'], source_node['y']]
+                    ]]
+                }
+            }
+            
+            features.append(reverse_feature)
+            feature_id += 1
+    
+    # Create the complete GeoJSON structure
+    geojson = {
+        "type": "FeatureCollection",
+        "name": "graph",
+        "crs": {
+            "type": "name",
+            "properties": {
+                "name": "urn:ogc:def:crs:EPSG::3857"
+            }
+        },
+        "date_generated": datetime.now().strftime("%a %b %d %I:%M:%S %p %Z %Y"),
+        "features": features
+    }
+    
+    return geojson
+
+
+def main():
+    """Main function to handle command line arguments and conversion."""
+    parser = argparse.ArgumentParser(description='Convert GML file to GeoJSON format')
+    parser.add_argument('input_file', help='Input GML file path')
+    parser.add_argument('-o', '--output', help='Output GeoJSON file path (default: input_file.geojson)')
+    
+    args = parser.parse_args()
+    
+    # Determine output file path
+    if args.output:
+        output_file = args.output
+    else:
+        output_file = args.input_file.rsplit('.', 1)[0] + '.geojson'
+    
+    try:
+        print(f"Parsing GML file: {args.input_file}")
+        nodes, edges = parse_gml_file(args.input_file)
+        print(f"Found {len(nodes)} nodes and {len(edges)} edges")
+        
+        print("Converting to GeoJSON...")
+        geojson = create_geojson(nodes, edges)
+        
+        print(f"Writing GeoJSON to: {output_file}")
+        with open(output_file, 'w') as f:
+            json.dump(geojson, f, indent=4)
+        
+        print("Conversion completed successfully!")
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+    
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/integration/nav2/tools/test/test_gml_to_geojson.py
+++ b/integration/nav2/tools/test/test_gml_to_geojson.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Tests for GML to GeoJSON Converter
+
+Tests the functionality of the gml_to_geojson.py module including
+GML parsing, GeoJSON conversion, and command line interface.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import mock_open, patch
+
+# Add the parent directory to the path to import the module under test
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from gml_to_geojson import create_geojson, main, parse_gml_file  # noqa: E402
+
+
+class TestGMLParser(unittest.TestCase):
+    """Test GML file parsing functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.sample_gml = """graph [
+node [
+id 1
+label "node1"
+world 10.5
+world 20.3
+world 0.0
+pixel 100
+pixel 200
+]
+node [
+id 2
+label "node2"
+world -5.2
+world 15.7
+pixel 150
+pixel 250
+]
+node [
+id 3
+label "node3"
+world 0.0
+world 0.0
+world 5.5
+]
+edge [
+source 1
+target 2
+weight 3.14
+edge_type "normal"
+]
+edge [
+source 2
+target 3
+weight 2.5
+]
+]"""
+
+        self.invalid_gml = """invalid content
+        no proper structure
+        """
+
+        self.partial_gml = """graph [
+node [
+id 1
+world 10.5
+world 20.3
+]
+node [
+id 2
+]
+edge [
+source 1
+]
+]"""
+
+    def test_parse_valid_gml_file(self):
+        """Test parsing a valid GML file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".gml", delete=False) as f:
+            f.write(self.sample_gml)
+            f.flush()
+
+            try:
+                nodes, edges = parse_gml_file(f.name)
+
+                # Test nodes
+                self.assertEqual(len(nodes), 3)
+
+                # Test first node
+                node1 = next(n for n in nodes if n["id"] == 1)
+                self.assertEqual(node1["label"], "node1")
+                self.assertEqual(node1["x"], 10.5)
+                self.assertEqual(node1["y"], 20.3)
+                self.assertEqual(node1["z"], 0.0)
+                self.assertEqual(node1["pixel_x"], 100)
+                self.assertEqual(node1["pixel_y"], 200)
+
+                # Test second node (no z coordinate)
+                node2 = next(n for n in nodes if n["id"] == 2)
+                self.assertEqual(node2["label"], "node2")
+                self.assertEqual(node2["x"], -5.2)
+                self.assertEqual(node2["y"], 15.7)
+                self.assertNotIn("z", node2)
+
+                # Test third node (no pixel coordinates)
+                node3 = next(n for n in nodes if n["id"] == 3)
+                self.assertEqual(node3["x"], 0.0)
+                self.assertEqual(node3["y"], 0.0)
+                self.assertEqual(node3["z"], 5.5)
+                self.assertNotIn("pixel_x", node3)
+
+                # Test edges
+                self.assertEqual(len(edges), 2)
+
+                # Test first edge
+                edge1 = next(e for e in edges if e["source"] == 1 and e["target"] == 2)
+                self.assertEqual(edge1["weight"], 3.14)
+                self.assertEqual(edge1["edge_type"], "normal")
+
+                # Test second edge
+                edge2 = next(e for e in edges if e["source"] == 2 and e["target"] == 3)
+                self.assertEqual(edge2["weight"], 2.5)
+                self.assertNotIn("edge_type", edge2)
+
+            finally:
+                os.unlink(f.name)
+
+    def test_parse_partial_gml_file(self):
+        """Test parsing GML file with missing or incomplete data."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".gml", delete=False) as f:
+            f.write(self.partial_gml)
+            f.flush()
+
+            try:
+                nodes, edges = parse_gml_file(f.name)
+
+                # Only nodes with id, x, and y should be included
+                self.assertEqual(len(nodes), 1)
+                self.assertEqual(nodes[0]["id"], 1)
+
+                # Edges without both source and target should be excluded
+                self.assertEqual(len(edges), 0)
+
+            finally:
+                os.unlink(f.name)
+
+    def test_parse_empty_file(self):
+        """Test parsing an empty file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".gml", delete=False) as f:
+            f.write("")
+            f.flush()
+
+            try:
+                nodes, edges = parse_gml_file(f.name)
+                self.assertEqual(len(nodes), 0)
+                self.assertEqual(len(edges), 0)
+            finally:
+                os.unlink(f.name)
+
+    def test_parse_nonexistent_file(self):
+        """Test parsing a non-existent file."""
+        with self.assertRaises(FileNotFoundError):
+            parse_gml_file("/nonexistent/file.gml")
+
+
+class TestGeoJSONCreation(unittest.TestCase):
+    """Test GeoJSON creation functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.nodes = [
+            {"id": 1, "x": 10.5, "y": 20.3, "label": "node1"},
+            {"id": 2, "x": -5.2, "y": 15.7, "label": "node2"},
+            {"id": 3, "x": 0.0, "y": 0.0, "label": "node3"},
+        ]
+
+        self.edges = [{"source": 1, "target": 2, "weight": 3.14}, {"source": 2, "target": 3, "weight": 2.5}]
+
+    def test_create_geojson_structure(self):
+        """Test that GeoJSON has correct structure."""
+        geojson = create_geojson(self.nodes, self.edges)
+
+        # Test basic structure
+        self.assertEqual(geojson["type"], "FeatureCollection")
+        self.assertEqual(geojson["name"], "graph")
+        self.assertIn("crs", geojson)
+        self.assertIn("date_generated", geojson)
+        self.assertIn("features", geojson)
+
+        # Test CRS
+        self.assertEqual(geojson["crs"]["type"], "name")
+        self.assertEqual(geojson["crs"]["properties"]["name"], "urn:ogc:def:crs:EPSG::3857")
+
+    def test_create_geojson_nodes(self):
+        """Test that nodes are correctly converted to Point features."""
+        geojson = create_geojson(self.nodes, [])
+        features = geojson["features"]
+
+        # Should have 3 point features
+        point_features = [f for f in features if f["geometry"]["type"] == "Point"]
+        self.assertEqual(len(point_features), 3)
+
+        # Test first node
+        node1_feature = next(f for f in point_features if f["properties"]["id"] == 1)
+        self.assertEqual(node1_feature["type"], "Feature")
+        self.assertEqual(node1_feature["properties"]["frame"], "map")
+        self.assertEqual(node1_feature["geometry"]["coordinates"], [10.5, 20.3])
+
+    def test_create_geojson_edges(self):
+        """Test that edges are correctly converted to LineString features."""
+        geojson = create_geojson(self.nodes, self.edges)
+        features = geojson["features"]
+
+        # Should have line features (2 edges * 2 directions = 4 line features)
+        line_features = [f for f in features if f["geometry"]["type"] == "MultiLineString"]
+        self.assertEqual(len(line_features), 4)
+
+        # Test forward edge from node 1 to node 2
+        forward_edge = next(
+            f for f in line_features if f["properties"]["startid"] == 1 and f["properties"]["endid"] == 2
+        )
+        expected_coords = [[10.5, 20.3], [-5.2, 15.7]]
+        self.assertEqual(forward_edge["geometry"]["coordinates"][0], expected_coords)
+
+        # Test reverse edge from node 2 to node 1
+        reverse_edge = next(
+            f for f in line_features if f["properties"]["startid"] == 2 and f["properties"]["endid"] == 1
+        )
+        expected_coords = [[-5.2, 15.7], [10.5, 20.3]]
+        self.assertEqual(reverse_edge["geometry"]["coordinates"][0], expected_coords)
+
+    def test_create_geojson_missing_nodes(self):
+        """Test handling of edges referencing non-existent nodes."""
+        edges_with_missing = [
+            {"source": 1, "target": 999},  # target doesn't exist
+            {"source": 2, "target": 3},  # valid edge
+        ]
+
+        geojson = create_geojson(self.nodes, edges_with_missing)
+        line_features = [f for f in geojson["features"] if f["geometry"]["type"] == "MultiLineString"]
+
+        # Should only have 2 line features (1 valid edge * 2 directions)
+        self.assertEqual(len(line_features), 2)
+
+    def test_create_geojson_empty_input(self):
+        """Test creating GeoJSON from empty nodes and edges."""
+        geojson = create_geojson([], [])
+
+        self.assertEqual(geojson["type"], "FeatureCollection")
+        self.assertEqual(len(geojson["features"]), 0)
+
+    def test_date_generation(self):
+        """Test that date is properly generated."""
+        geojson = create_geojson([], [])
+        # Just verify that a date string is generated
+        self.assertIn("date_generated", geojson)
+        self.assertIsInstance(geojson["date_generated"], str)
+        self.assertGreater(len(geojson["date_generated"]), 0)
+
+
+class TestMainFunction(unittest.TestCase):
+    """Test the main function and command line interface."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.sample_gml = """graph [
+node [
+id 1
+label "test"
+world 0.0
+world 0.0
+]
+edge [
+source 1
+target 1
+]
+]"""
+
+    @patch("sys.argv", ["gml_to_geojson.py", "test.gml"])
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("gml_to_geojson.parse_gml_file")
+    @patch("json.dump")
+    def test_main_default_output(self, mock_json_dump, mock_parse, mock_file):
+        """Test main function with default output filename."""
+        mock_parse.return_value = ([], [])
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_parse.assert_called_once_with("test.gml")
+        # Check that output file was opened with .geojson extension
+        mock_file.assert_called_with("test.geojson", "w")
+
+    @patch("sys.argv", ["gml_to_geojson.py", "input.gml", "-o", "custom.geojson"])
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("gml_to_geojson.parse_gml_file")
+    @patch("json.dump")
+    def test_main_custom_output(self, mock_json_dump, mock_parse, mock_file):
+        """Test main function with custom output filename."""
+        mock_parse.return_value = ([], [])
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_parse.assert_called_once_with("input.gml")
+        mock_file.assert_called_with("custom.geojson", "w")
+
+    @patch("sys.argv", ["gml_to_geojson.py", "test.gml"])
+    @patch("gml_to_geojson.parse_gml_file")
+    def test_main_error_handling(self, mock_parse):
+        """Test main function error handling."""
+        mock_parse.side_effect = Exception("Test error")
+
+        result = main()
+
+        self.assertEqual(result, 1)
+
+    def test_integration_full_workflow(self):
+        """Integration test of the complete workflow."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".gml", delete=False) as input_file:
+            input_file.write(self.sample_gml)
+            input_file.flush()
+
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".geojson", delete=False) as output_file:
+                output_file.close()  # Close so main can write to it
+
+                try:
+                    # Test the complete workflow
+                    with patch("sys.argv", ["gml_to_geojson.py", input_file.name, "-o", output_file.name]):
+                        result = main()
+
+                    self.assertEqual(result, 0)
+
+                    # Verify output file was created and contains valid GeoJSON
+                    with open(output_file.name) as f:
+                        geojson_content = json.load(f)
+
+                    self.assertEqual(geojson_content["type"], "FeatureCollection")
+                    self.assertIn("features", geojson_content)
+
+                finally:
+                    os.unlink(input_file.name)
+                    os.unlink(output_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a script for converting the gml files into geojson with directional edges to make SWAGGER useful for the Nav2 Route Server.

This can be tested with the following workflow:
- Create a gml file using SWAGGER
- Create a geojson file from the gml file using this script
- Create a yaml file to correspond to your map png file, if not already present
- Update `nav2_params.yaml` to use `default_nav_to_pose_bt_xml: $(find-pkg-share nav2_bt_navigator)/behavior_trees/navigate_on_route_graph_w_recovery.xml` in the BT navigator for a route BT XML behavior
- Run the following:
```
ros2 launch nav2_bringup tb4_loopback_simulation_launch.py map:=/path/to/your/map.yaml graph:=/path/to/your/graph.geojson
```

Happy navigating! 

https://github.com/user-attachments/assets/6ca0d4e1-6d27-4e0a-b67b-9b8cd563ac2e

P.S. Great job on this work - it 'just worked' as expected without much fuss and the output format was easy to work with. I will definitely tie this work back into Nav2's docs shortly!

